### PR TITLE
modify err 500 to 409

### DIFF
--- a/src/middlewares/errorHandler.js
+++ b/src/middlewares/errorHandler.js
@@ -12,10 +12,17 @@ export const errorHandler = (err, _req, res, _next) => {
       });
     }
 
-    return res.status(err.status).json({
+    const response = {
       status: err.status,
       message: err.message || 'Something went wrong',
-    });
+    };
+
+    // Optional detailed error for specific cases like 409 Conflict
+    if (err.error) {
+      response.error = err.error;
+    }
+
+    return res.status(err.status).json(response);
   }
 
   res.status(500).json({

--- a/src/middlewares/swaggerDocs.js
+++ b/src/middlewares/swaggerDocs.js
@@ -8,7 +8,7 @@ export const swaggerDocs = () => {
   try {
     const swaggerDoc = JSON.parse(fs.readFileSync(SWAGGER_PATH).toString());
     return [...swaggerUI.serve, swaggerUI.setup(swaggerDoc)];
-  } catch (err) {
+  } catch {
     return (req, res, next) =>
       next(createHttpError(500, "Can't load swagger docs"));
   }

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,3 +1,4 @@
+import createHttpError from 'http-errors';
 import bcrypt from 'bcrypt';
 import { UsersCollections } from '../db/models/user.js';
 
@@ -6,7 +7,9 @@ import { UsersCollections } from '../db/models/user.js';
 export const registerUser = async (name, email, password) => {
   const existingUser = await UsersCollections.findOne({ email });
   if (existingUser) {
-    throw new Error('Email in use');
+    throw createHttpError(409, 'Something went wrong', {
+      error: 'Email in use',
+    });
   }
 
   const hashedPassword = await bcrypt.hash(password, 10);


### PR DESCRIPTION
Трохи модифікував, щоб при спробі реєстрації користувача з існуючим e-mail поверталась помилка 409, а не 500. Саме так і прописав у документації.

Зміни по собі робив у файлах:
- \src\middlewares\errorHandler.js;
- src/services/auth.js.

У файлі src/middlewares/swaggerDocs.js прибрав "err", бо на нього сварився черовненьким VS. 